### PR TITLE
Hotfix/add cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@
 ### Go
 - [Effective Go](https://golang.org/doc/effective_go.html)
 
+### Groovy
+- [Apache Groovy style guide](http://groovy-lang.org/style-guide.html)
+
 ### Haskell
 - [Haskell Programming guidelines](https://wiki.haskell.org/Programming_guidelines)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 ### C++
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+- [Clang format style options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options) - Links to LLVM, Google, Chromium, Mozilla, and WebKit
 - [C++ Core Guidelines](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) - A set of tried-and-true guidelines, rules, and best practices about coding in C++.
 
 ### Clojure


### PR DESCRIPTION
I added a link to the Clang format style options, which includes a few other C++ coding standards. Perhaps we should copy and link all of them here though? I'll leave that up to you to decide.

I also added a section for Groovy and a link to the official coding style guide.

This is my first pull request so I apologize if I made any mistakes. Thanks!