### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ### C#
 - [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions)
 - [C# Style Guide](https://github.com/raywenderlich/c-sharp-style-guide)
-- [C# Coding Standards and Naming Conventions](http://www.dofactory.com/error/error?aspxerrorpath=/reference/csharp-coding-standards)
+- [C# Coding Standards and Naming Conventions](http://www.dofactory.com/reference/csharp-coding-standards)
 
 ### C++
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ### C#
 - [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions)
 - [C# Style Guide](https://github.com/raywenderlich/c-sharp-style-guide)
-- [C# Coding Standards and Naming Conventions](http://www.dofactory.com/reference/csharp-coding-standards)
+- [C# Coding Standards and Naming Conventions](http://www.dofactory.com/error/error?aspxerrorpath=/reference/csharp-coding-standards)
 
 ### C++
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
@@ -49,7 +49,7 @@
 - [Erlang Coding Guidelines](https://github.com/inaka/erlang_guidelines)
 
 ### F#
-- [The F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines)
+- [The F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
 ### Go
 - [Effective Go](https://golang.org/doc/effective_go.html)
@@ -234,7 +234,7 @@ Contributions welcome! Read the [contribution guidelines](contributing.md) first
 
 ## License
 
-[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](http://creativecommons.org/publicdomain/zero/1.0)
+[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)
 
 To the extent possible under law, [Wahyu Kristianto](https://github.com/Kristories) has waived all copyright and
 related or neighboring rights to this work.


### PR DESCRIPTION
### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://creativecommons.org/publicdomain/zero/1.0 | https://creativecommons.org/publicdomain/zero/1.0 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://fsharp.org/specs/component-design-guidelines | http://fsharp.org/specs/component-design-guidelines/ 
http://www.dofactory.com/reference/csharp-coding-standards | http://www.dofactory.com/reference/csharp-coding-standards
