### PR TITLE
Added Fortran 90 standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 - [The F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
 ### Fortran
-- [Fortran 90 Standards](http://research.metoffice.gov.uk/research/nwp/numerical/fortran90/f90_standards.html) - European Standards For Writing and Documenting Exchangeable Fortran 90 Code
+- [Fortran 90 Standards](http://research.metoffice.gov.uk/research/nwp/numerical/fortran90/f90_standards.html) - European Standards For Writing and Documenting Exchangeable Fortran 90 Code.
 
 ### Go
 - [Effective Go](https://golang.org/doc/effective_go.html)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@
 ### F#
 - [The F# Component Design Guidelines](http://fsharp.org/specs/component-design-guidelines/)
 
+### Fortran
+- [Fortran 90 Standards](http://research.metoffice.gov.uk/research/nwp/numerical/fortran90/f90_standards.html) - European Standards For Writing and Documenting Exchangeable Fortran 90 Code
+
 ### Go
 - [Effective Go](https://golang.org/doc/effective_go.html)
 


### PR DESCRIPTION
This standard for Fortran 90 is also used by a wide range of organisations outside Europe that interact with Numerical Weather Prediction code.