### PR TITLE
Remove a duplicate link to the perlstyle doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@
 
 ### Perl
 - [perlstyle](https://perldoc.perl.org/perlstyle.html)
-- [Perl style guide](http://search.cpan.org/dist/perl/pod/perlstyle.pod)
 
 ### PHP
 - [PHP FIG](http://www.php-fig.org/psr/) - PHP Standards Recommendations.


### PR DESCRIPTION
The one at search.cpan.org links inside the perl core distribution which
is used to generate perldoc.perl.org so no point in having a dup one.