### PR TITLE
Removing death link for Ambassador guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ A set of guidelines for a specific programming language that recommend programmi
 - [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html)
 - [Guidelines for Responsive Web Design](https://www.smashingmagazine.com/2011/01/guidelines-for-responsive-web-design/)
 - [Yelp Styleguide](https://www.yelp.com/styleguide)
-- [Ambassador Conventions](http://conventions.getambassador.com) - A UX and design pattern library for all Ambassador apps.
 - [Front-End Checklist](https://github.com/thedaviddias/Front-End-Checklist)
 
 ### GNU


### PR DESCRIPTION
Hey @Kristories,

just removing a death link for the Ambassador guides. I couldn't find a replacement.

Cheers,
Peter

**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/Kristories/awesome-guidelines/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

⬆⬆⬆⬆⬆⬆⬆⬆⬆⬆
