### PR TITLE
Updated README.md to replace a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ A set of guidelines for a specific programming language that recommend programmi
 
 ### Rust
 
-- [Rust Style Guide](https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md)
+- [Rust Style Guide](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src)
 - [Rust Guidelines](http://aturon.github.io)
 - [Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/)
 


### PR DESCRIPTION
**Summary:**
Updated Rust Style Guide dead link.

- **Issue:**
This pull request addresses the issue of a broken link that currently leads to a 404 page. It replaces the broken link with the correct updated location.

- **Proposed Changes:**

  - Replace the broken link: https://github.com/rust-lang/style-team/blob/main/guide/guide.md
  - With the updated location: https://github.com/rust-lang/rust/tree/master/src/doc/style-guide/src


**By submitting this pull request, I promise I have read the [contribution guidelines](https://github.com/Kristories/awesome-guidelines/blob/master/contributing.md) twice and ensured my submission follows it. I realize not doing so wastes the maintainers' time that they could have spent making the world better. 🖖**

