### PR TITLE
Updated angular style guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ A set of guidelines for a specific programming language that recommend programmi
 - [Symfony Coding Standards](https://symfony.com/doc/current/contributing/code/standards.html)
 - [Django Coding Style](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style)
 - [Vue Style Guide](https://vuejs.org/style-guide)
-- [Angular Style Guide](https://angular.io/guide/styleguide)
+- [Angular Style Guide](https://angular.dev/style-guide)
 
 ## Content Management System
 


### PR DESCRIPTION
The `angualr.io` style guide link is no longer maintained. This PR updates it to the new `angular.dev` link.